### PR TITLE
Fix marginal effects for quadratic terms

### DIFF
--- a/R/Interplot_default.R
+++ b/R/Interplot_default.R
@@ -174,13 +174,16 @@ interplot.default <- function(m, var1, var2, plot = TRUE, point = FALSE, sims = 
         
         
     } else {
+        ## Correct marginal effect for quadratic terms
+        multiplier <- if (var1 == var2) 2 else 1
+
         for (i in 1:steps) {
-            coef$coef1[i] <- mean(m.sims@coef[, match(var1, names(m$coef))] + coef$fake[i] * 
+            coef$coef1[i] <- mean(m.sims@coef[, match(var1, names(m$coef))] + multiplier * coef$fake[i] * 
                 m.sims@coef[, match(var12, names(m$coef))])
             coef$ub[i] <- quantile(m.sims@coef[, match(var1, names(m$coef))] + 
-                coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.975)
+                multiplier * coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.975)
             coef$lb[i] <- quantile(m.sims@coef[, match(var1, names(m$coef))] + 
-                coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.025)
+                multiplier * coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.025)
         }
         
         if (plot == TRUE) {

--- a/R/Interplot_mi.R
+++ b/R/Interplot_mi.R
@@ -173,13 +173,16 @@ interplot.lmmi <- function(m, var1, var2, plot = TRUE, point = FALSE, sims = 500
         
         
     } else {
+        ## Correct marginal effect for quadratic terms
+        multiplier <- if (var1 == var2) 2 else 1
+
         for (i in 1:steps) {
-            coef$coef1[i] <- mean(m.sims@coef[, match(var1, names(m$coef))] + coef$fake[i] * 
+            coef$coef1[i] <- mean(m.sims@coef[, match(var1, names(m$coef))] + multiplier * coef$fake[i] * 
                 m.sims@coef[, match(var12, names(m$coef))])
             coef$ub[i] <- quantile(m.sims@coef[, match(var1, names(m$coef))] + 
-                coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.975)
+                multiplier * coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.975)
             coef$lb[i] <- quantile(m.sims@coef[, match(var1, names(m$coef))] + 
-                coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.025)
+                multiplier * coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.025)
         }
         
         if (plot == TRUE) {
@@ -339,13 +342,16 @@ interplot.glmmi <- function(m, var1, var2, plot = TRUE, point = FALSE, sims = 50
         
         
     } else {
+        ## Correct marginal effect for quadratic terms
+        multiplier <- if (var1 == var2) 2 else 1
+
         for (i in 1:steps) {
-            coef$coef1[i] <- mean(m.sims@coef[, match(var1, names(m$coef))] + coef$fake[i] * 
+            coef$coef1[i] <- mean(m.sims@coef[, match(var1, names(m$coef))] + multiplier * coef$fake[i] * 
                 m.sims@coef[, match(var12, names(m$coef))])
             coef$ub[i] <- quantile(m.sims@coef[, match(var1, names(m$coef))] + 
-                coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.975)
+                multiplier * coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.975)
             coef$lb[i] <- quantile(m.sims@coef[, match(var1, names(m$coef))] + 
-                coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.025)
+                multiplier * coef$fake[i] * m.sims@coef[, match(var12, names(m$coef))], 0.025)
         }
         
         if (plot == TRUE) {

--- a/R/Interplot_mlm.R
+++ b/R/Interplot_mlm.R
@@ -163,14 +163,17 @@ interplot.lmerMod <- function(m, var1, var2, plot = TRUE, point = FALSE, sims = 
         
         
     } else {
+        ## Correct marginal effect for quadratic terms
+        multiplier <- if (var1 == var2) 2 else 1
+
         for (i in 1:steps) {
             coef$coef1[i] <- mean(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))])
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))])
             coef$ub[i] <- quantile(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
                 0.975)
             coef$lb[i] <- quantile(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
                 0.025)
         }
         
@@ -322,14 +325,17 @@ interplot.glmerMod <- function(m, var1, var2, plot = TRUE, point = FALSE, sims =
         
         
     } else {
+        ## Correct marginal effect for quadratic terms
+        multiplier <- if (var1 == var2) 2 else 1
+
         for (i in 1:steps) {
             coef$coef1[i] <- mean(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))])
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))])
             coef$ub[i] <- quantile(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
                 0.975)
             coef$lb[i] <- quantile(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
                 0.025)
         }
         

--- a/R/Interplot_mlmmi.R
+++ b/R/Interplot_mlmmi.R
@@ -173,14 +173,17 @@ interplot.mlmmi <- function(m, var1, var2, plot = TRUE, point = FALSE, sims = 50
         
         
     } else {
+        ## Correct marginal effect for quadratic terms
+        multiplier <- if (var1 == var2) 2 else 1
+
         for (i in 1:steps) {
             coef$coef1[i] <- mean(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))])
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))])
             coef$ub[i] <- quantile(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
                 0.975)
             coef$lb[i] <- quantile(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
                 0.025)
         }
         
@@ -341,14 +344,17 @@ interplot.gmlmmi <- function(m, var1, var2, plot = TRUE, point = FALSE, sims = 5
         
         
     } else {
+        ## Correct marginal effect for quadratic terms
+        multiplier <- if (var1 == var2) 2 else 1
+
         for (i in 1:steps) {
             coef$coef1[i] <- mean(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))])
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))])
             coef$ub[i] <- quantile(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
                 0.975)
             coef$lb[i] <- quantile(m.sims@fixef[, match(var1, unlist(dimnames(m@pp$X)[2]))] + 
-                coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
+                multiplier * coef$fake[i] * m.sims@fixef[, match(var12, unlist(dimnames(m@pp$X)[2]))], 
                 0.025)
         }
         


### PR DESCRIPTION
In a model of the form

    y = b0 + b1 * x + b2 * x^2 + ...

the marginal effect of `x` is `b1 + 2 * b2 * x`.  Previously, `interplot()` instead calculated `b1 + b2 * x`.

This PR passes `R CMD build interplot && R CMD check --as-cran interplot_0.1.1.1.tar.gz` with no warnings or errors.